### PR TITLE
Fix missing commas in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ import { addDecorator } from '@storybook/react';
 
 addDecorator(
   withNextRouter({
-    path: '/' // defaults to `/`
-    asPath: '/' // defaults to `/`
+    path: '/', // defaults to `/`
+    asPath: '/', // defaults to `/`
     query: {}, // defaults to `{}`
     push() {} // defaults to using addon actions integration, can override any method in the router
   })


### PR DESCRIPTION
The JavaScript code in `preview.js` example isn't valid as there're missing trailing commas.

Otherwise the addon seems to be working, thank you very much! Really helped me 👏 