### PR TITLE
Add next@10.x to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "module": "dist/storybook-addon-next-router.esm.js",
   "name": "storybook-addon-next-router",
   "peerDependencies": {
-    "next": "9.x",
+    "next": "9.x || 10.x",
     "react": "16.x",
     "react-dom": "16.x"
   },


### PR DESCRIPTION
Makes the add-on compatible with projects running [Next.js 10.x](https://github.com/vercel/next.js/releases), without having to `--force` dependency conflicts:

```
npm ERR! While resolving: project@1.0.0
npm ERR! Found: next@10.0.3
npm ERR! node_modules/next
npm ERR!   next@"latest" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer next@"9.x" from storybook-addon-next-router@2.0.0
npm ERR! node_modules/storybook-addon-next-router
npm ERR!   dev storybook-addon-next-router@"^2.0.0" from the root project
```

Closes #4