### PR TITLE
Support React 17 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "@storybook/addon-actions": "6.x",
     "@storybook/addons": "6.x",
     "next": "9.x || 10.x",
-    "react": "16.x",
-    "react-dom": "16.x"
+    "react": "16.x || 17.x",
+    "react-dom": "16.x || 17.x"
   },
   "prettier": {
     "printWidth": 80,


### PR DESCRIPTION
Works great with react 17, just need to indicate it. This will solve peer dependency problems, and issues that npm 7 will have with unmet peer deps.