### PR TITLE
Compatibility with next v11.2

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { makeDecorator } from '@storybook/addons';
 import React from 'react';
 import Router, { NextRouter } from 'next/router';
-import { RouterContext } from 'next/dist/next-server/lib/router-context';
+import { RouterContext } from 'next/dist/shared/lib/router-context';
 
 export const withNextRouter = makeDecorator({
   name: 'NextRouter',


### PR DESCRIPTION
In next v11.2 canary the router context has been moved into a `shared` directory: https://github.com/vercel/next.js/pull/26734

