### PR TITLE
feat(locale): add support for locale from globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ Example.story = {
 ```js
 import { withNextRouter } from 'storybook-addon-next-router';
 
-export decorators = [
-  withNextRouter
-];
+addDecorator(withNextRouter);
 ```
 
 ### Custom
@@ -52,18 +50,21 @@ export decorators = [
 ```js
 import { withNextRouter } from 'storybook-addon-next-router';
 
-export decorators = [
-  withNextRouter({
-    path: '/', // defaults to `/`
-    asPath: '/', // defaults to `/`
-    query: {}, // defaults to `{}`
-    push() {} // defaults to using addon actions integration, can override any method in the router
-  })
-];
+export const parameters = {
+    nextRouter: {
+        path: '/', // defaults to `/`
+        asPath: '/', // defaults to `/`
+        query: {}, // defaults to `{}`
+        push() {
+        } // defaults to using addon actions integration, can override any method in the router
+    }
+};
+
+addDecorator(withNextRouter);
 ```
 
 
-if you set up `withNextRouter` in preview, it will not need to be added to the `decorators` key in each story, consider doing this if you have a lot of stories that depend on Apollo.
+If you set up `withNextRouter` in preview, it will not need to be added to the `decorators` key in each story, consider doing this if you have a lot of stories that depend on Apollo.
 
 Read more about the options available for next/router at https://nextjs.org/docs/api-reference/next/router
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,59 +1,58 @@
 import { action } from '@storybook/addon-actions';
-import { makeDecorator } from '@storybook/addons';
 import React from 'react';
 import Router, { NextRouter } from 'next/router';
 import { RouterContext } from 'next/dist/next-server/lib/router-context';
+import {useGlobals} from '@storybook/client-api';
 
-export const withNextRouter = makeDecorator({
-  name: 'NextRouter',
-  parameterName: 'nextRouter',
-  wrapper(getStory, context, settings) {
-    Router.router = {
-      route: '/',
-      pathname: '/',
-      query: {},
-      asPath: '/',
-      push(...args) {
-        action('nextRouter.push')(...args);
-        return Promise.resolve(true);
-      },
-      replace(...args) {
-        action('nextRouter.replace')(...args);
-        return Promise.resolve(true);
-      },
-      reload(...args) {
-        action('nextRouter.reload')(...args);
-      },
-      back(...args) {
-        action('nextRouter.back')(...args);
-      },
-      prefetch(...args) {
-        action('nextRouter.prefetch')(...args);
-        return Promise.resolve();
-      },
-      beforePopState(...args) {
-        action('nextRouter.beforePopState')(...args);
-      },
-      events: {
-        on(...args) {
-          action('nextRouter.events.on')(...args);
-        },
-        off(...args) {
-          action('nextRouter.events.off')(...args);
-        },
-        emit(...args) {
-          action('nextRouter.events.emit')(...args);
-        },
-      },
-      isFallback: false,
-      ...settings.options,
-      ...settings.parameters,
-    } as typeof Router.router;
+export const withNextRouter = (story, context) => {
+  const [{locale}] = useGlobals();
+  const {parameters: {nextRouter}} = context;
 
-    return (
-      <RouterContext.Provider value={Router.router as NextRouter}>
-        {getStory(context)}
-      </RouterContext.Provider>
-    );
-  },
-});
+  Router.router = {
+    locale,
+    route: '/',
+    pathname: '/',
+    query: {},
+    asPath: '/',
+    push(...args) {
+      action('nextRouter.push')(...args);
+      return Promise.resolve(true);
+    },
+    replace(...args) {
+      action('nextRouter.replace')(...args);
+      return Promise.resolve(true);
+    },
+    reload(...args) {
+      action('nextRouter.reload')(...args);
+    },
+    back(...args) {
+      action('nextRouter.back')(...args);
+    },
+    prefetch(...args) {
+      action('nextRouter.prefetch')(...args);
+      return Promise.resolve();
+    },
+    beforePopState(...args) {
+      action('nextRouter.beforePopState')(...args);
+    },
+    events: {
+      on(...args) {
+        action('nextRouter.events.on')(...args);
+      },
+      off(...args) {
+        action('nextRouter.events.off')(...args);
+      },
+      emit(...args) {
+        action('nextRouter.events.emit')(...args);
+      },
+    },
+    isFallback: false,
+    ...nextRouter,
+  } as typeof Router.router;
+
+  return (
+    <RouterContext.Provider value={Router.router as NextRouter}>
+      {story(context)}
+    </RouterContext.Provider>
+  );
+};


### PR DESCRIPTION
I've made three improvements.

First, instead of using makeDecorator, this is now just a decorator.

Second, I moved the next router overrides into the "nextRouter" parameter regardless of whether it's used in a stories.js or preview.js. This is more in line with Storybook's preferred methodology moving forward.

Third, I added support for the locale property from globals. If you're not using any i18n, this won't do anything. If you are, it will put the locale into the router as expected.
```javascript
const router = useRouter();
console.log(router.locale);
```

The reason I'm using global for locale and not parameter is so it can be changed on the fly (I have other addons coming shortly which will make use of this for i18next and react-intl, to name just two).