### PR TITLE
docs: fix RouterContext path

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ module.exports = {
 Add the RouterContext.Provider to `.storybook/preview.js`
 
 ```js
-import { RouterContext } from "next/dist/shared/lib/router-context"; // next 11.2
-import { RouterContext } from "next/dist/next-server/lib/router-context"; // next < 11.2
+import { RouterContext } from "next/dist/shared/lib/router-context"; // next 11.1
+import { RouterContext } from "next/dist/next-server/lib/router-context"; // next < 11.1
 
 
 export const parameters = {


### PR DESCRIPTION
README says "import from shared/lib above 11.2", but this change is also included Next.js v11.1.0 (and v11.0.2-canary). The commit includes the change about the path of `RouterContext` is below.

https://github.com/vercel/next.js/commit/136b75439612bf6f2f0cd3fd0d8226fdaa8c0f95