### PR TITLE
Fix import for Next 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ module.exports = {
 Add the RouterContext.Provider to `.storybook/preview.js`
 
 ```js
-import { RouterContext } from "next/dist/shared/lib/router-context"; // next 11.1
-import { RouterContext } from "next/dist/next-server/lib/router-context"; // next < 11.1
-
+import { RouterContext } from "next/dist/shared/lib/router-context"; // next 12
+// import { RouterContext } from "next/dist/shared/lib/router-context"; // next 11.1
+// import { RouterContext } from "next/dist/next-server/lib/router-context"; // next < 11.1
 
 export const parameters = {
   nextRouter: {


### PR DESCRIPTION
router-context has moved again, see Next.js PR for a definitive fix: https://github.com/vercel/next.js/pull/28528, and https://github.com/lifeiscontent/storybook-addon-next-router/issues/35