### PR TITLE
chore: update docs for next.js 13 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ module.exports = {
 Add the RouterContext.Provider to `.storybook/preview.js`
 
 ```js
-import { RouterContext } from "next/dist/shared/lib/router-context"; // next 12
+import { AppRouterContext } from "next/dist/shared/lib/app-router-context"; // next 13 next 13 (using next/navigation)
+// import { RouterContext } from "next/dist/shared/lib/router-context"; // next 13 (using next/router) / next 12
 // import { RouterContext } from "next/dist/shared/lib/router-context"; // next 11.1
 // import { RouterContext } from "next/dist/next-server/lib/router-context"; // next < 11.1
 
 export const parameters = {
   nextRouter: {
-    Provider: RouterContext.Provider,
+    Provider: AppRouterContext.Provider, // next 13 next 13 (using next/navigation)
+    // Provider: RouterContext.Provider, // next 13 (using next/router) / next < 12
   },
 }
 ```


### PR DESCRIPTION
I want to update the docs related to implementation of next.js 13, this documentation covers the use of `next/router` and `next/navigation`

I've tried it in my project and it worked, here's the environment in my project:
* **next v13.0.4**
* **react v18.2.0**
* **react-dom v18.2.0**
* **storybook-addon-next-router v4.0.1**